### PR TITLE
Use tempfile (mkstemp)

### DIFF
--- a/Decompile to Text Editor.py
+++ b/Decompile to Text Editor.py
@@ -27,7 +27,7 @@ def main():
     head = proc.signatureString()
     code = proc.decompile()
 
-    with tempfile.NamedTemporaryFile('w', suffix=".m") as temp:
+    with tempfile.NamedTemporaryFile('w+t', suffix='.m') as temp:
         temp.write("%s {\n%s}\n" % (head, code))
         temp.flush()
         os.system(f"{EDITOR} '{temp.name}'")


### PR DESCRIPTION
This will generate a safe temporary file in the per-user temp dir,
and unlink it on close. Previously files were left in /tmp each time.